### PR TITLE
Moves the build-and-push job for 2023 back into the build matrix

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,36 +37,7 @@ jobs:
     timeout-minutes: 1440
     strategy:
       matrix:
-        year: [2017, 2018, 2019, 2020, 2021, 2022]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./${{ matrix.year }}
-          push: true
-          tags: maxkratz/texlive:${{ matrix.year }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-        timeout-minutes: 1440
-
-  build-and-push-image-2023:
-    # Use a self-hosted runner to circumvent the small storage size of GitHub-hosted runners
-    runs-on: [self-hosted]
-    needs: [build-and-push-base]
-    timeout-minutes: 1440
-    strategy:
-      matrix:
-        year: [2023]
+        year: [2017, 2018, 2019, 2020, 2021, 2022, 2023]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
... since all images will be built by self-hosted runners anyway

Closes #36.