### PR TITLE
Updates GitHub Action checkout to v7

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -40,7 +40,7 @@ jobs:
         year: [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -70,7 +70,7 @@ jobs:
         year: [2026]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -100,7 +100,7 @@ jobs:
         year: [2022-gradle, 2023-gradle, 2023-python, 2024-gradle, 2024-python, 2025-gradle, 2025-python, 2026-gradle, 2026-python]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -129,7 +129,7 @@ jobs:
         year: [2016]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ubuntu-24.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -35,7 +35,7 @@ jobs:
         year: [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -58,7 +58,7 @@ jobs:
         year: [2022-gradle, 2023-gradle, 2023-python, 2024-gradle, 2024-python, 2025-gradle, 2025-python, 2026-gradle, 2026-python]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -82,7 +82,7 @@ jobs:
         year: [2026]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -109,7 +109,7 @@ jobs:
         year: [2016]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx


### PR DESCRIPTION
Blocked by https://github.com/actions/checkout/issues/2470.