### PR TITLE
Updates Gradle to v9.7.1

### DIFF
--- a/2022-gradle/Dockerfile
+++ b/2022-gradle/Dockerfile
@@ -3,7 +3,7 @@ FROM maxkratz/texlive:2022
 LABEL maintainer="Max Kratz <github@maxkratz.com>"
 
 # Config
-ARG GRADLE_VERSION=9.7.0
+ARG GRADLE_VERSION=9.7.1
 
 # Install OpenJDK 21
 RUN apt-get update -q && \

--- a/2023-gradle/Dockerfile
+++ b/2023-gradle/Dockerfile
@@ -3,7 +3,7 @@ FROM maxkratz/texlive:2023
 LABEL maintainer="Max Kratz <github@maxkratz.com>"
 
 # Config
-ARG GRADLE_VERSION=9.7.0
+ARG GRADLE_VERSION=9.7.1
 
 # Install OpenJDK 21
 RUN apt-get update -q && \

--- a/2024-gradle/Dockerfile
+++ b/2024-gradle/Dockerfile
@@ -3,7 +3,7 @@ FROM maxkratz/texlive:2024
 LABEL maintainer="Max Kratz <github@maxkratz.com>"
 
 # Config
-ARG GRADLE_VERSION=9.7.0
+ARG GRADLE_VERSION=9.7.1
 
 # Install OpenJDK 21
 RUN apt-get update -q && \

--- a/2025-gradle/Dockerfile
+++ b/2025-gradle/Dockerfile
@@ -3,7 +3,7 @@ FROM maxkratz/texlive:2025
 LABEL maintainer="Max Kratz <github@maxkratz.com>"
 
 # Config
-ARG GRADLE_VERSION=9.7.0
+ARG GRADLE_VERSION=9.7.1
 
 # Install OpenJDK 21
 RUN apt-get update -q && \

--- a/2026-gradle/Dockerfile
+++ b/2026-gradle/Dockerfile
@@ -3,7 +3,7 @@ FROM maxkratz/texlive:2026
 LABEL maintainer="Max Kratz <github@maxkratz.com>"
 
 # Config
-ARG GRADLE_VERSION=9.7.0
+ARG GRADLE_VERSION=9.7.1
 
 # Install OpenJDK 21
 RUN apt-get update -q && \


### PR DESCRIPTION
Closes #120.

Currently blocked by the CI build because http://ftp.math.utah.edu is offline again.